### PR TITLE
argoproj/argocd-image-updater: init at 0.12.1

### DIFF
--- a/charts/argoproj/argocd-image-updater/default.nix
+++ b/charts/argoproj/argocd-image-updater/default.nix
@@ -1,0 +1,6 @@
+{
+  repo = "https://argoproj.github.io/argo-helm/";
+  chart = "argocd-image-updater";
+  version = "0.12.1";
+  chartHash = "sha256-9f5KmAD7k7nVfcOmB//q8aHrCNO8kcLXj2c8qk9yTtc=";
+}


### PR DESCRIPTION
This works along-side argocd, my configuration looks something like this:
```nix
({...}: let
  kubelib = inputs.kubelib.lib {inherit pkgs;};
  nhcharts = inputs.nixhelm.charts {inherit pkgs;};
in {
  services.k3s = {
    clusterInit = true;
    manifests = {
      # {...}
      argocd-install = {
        enable = true;
        source = kubelib.buildHelmChart {
          name = "argocd";
          namespace = "argocd";
          chart = nhcharts.argoproj.argo-cd;
          values = {
            # Traefik will handle ssl for us :)
            configs.params."server.insecure" = true;
          };
        };
      };
      argocd-image-updater-install = {
        enable = true;
        source = kubelib.buildHelmChart {
          name = "argocd-image-updater";
          namespace = "argocd";
          chart = nhcharts.argoproj.argocd-image-updater;
          values = {
            # https://github.com/argoproj/argo-helm/tree/main/charts/argocd-image-updater#configuration-options
            config.argocd = {
              arpcWeb = false;
              serverAddress = "https://argocd.example.com";
              insecure = true;
              plaintext = false;
            };
          };
        };
      };
    };
  };
})
```
