### PR TITLE
emqx/emqx-operator: init at 2.2.29

### DIFF
--- a/charts/emqx/emqx-operator/default.nix
+++ b/charts/emqx/emqx-operator/default.nix
@@ -1,0 +1,6 @@
+{
+  repo = "https://repos.emqx.io/charts/";
+  chart = "emqx-operator";
+  version = "2.2.29";
+  chartHash = "sha256-v3icqMl1uTklas01M0WnGekIapviaa9zmhnhQJ3/5/Y=";
+}

--- a/charts/emqx/emqx/default.nix
+++ b/charts/emqx/emqx/default.nix
@@ -1,6 +1,0 @@
-{
-  repo = "https://repos.emqx.io/charts/";
-  chart = "emqx";
-  version = "5.8.6";
-  chartHash = "sha256-no99jOD0yiBoShfBFQK9MZL8Yu9WHVz0iMPXAPi9q3w=";
-}


### PR DESCRIPTION
im sorry for the inconvenience, the given helm chart is the old way of deploying emqx.

Emqx changed to operator deployments recently. Thus, i would like to move the emqx chart to the operator.

Kind regards
Alexanser