### PR TITLE
koenkk/zigbee2mqtt: init at 2.5.1

### DIFF
--- a/charts/koenkk/zigbee2mqtt/default.nix
+++ b/charts/koenkk/zigbee2mqtt/default.nix
@@ -1,0 +1,6 @@
+{
+  repo = "https://koenkk.github.io/zigbee2mqtt-chart/";
+  chart = "zigbee2mqtt";
+  version = "2.5.1";
+  chartHash = "sha256-yfrkGixTOP0zxk8ewzuzcgve5pEj48Wd4pbsCbUoyZY=";
+}


### PR DESCRIPTION
chart is maintained by the creator of zigbee2mqtt.
tyvm.