### PR TITLE
hcloud/hcloud-cloud-controller-manager: init at 1.26.0

### DIFF
--- a/charts/hcloud/hcloud-cloud-controller-manager/default.nix
+++ b/charts/hcloud/hcloud-cloud-controller-manager/default.nix
@@ -1,0 +1,6 @@
+{
+  repo = "https://charts.hetzner.cloud/";
+  chart = "hcloud-cloud-controller-manager";
+  version = "1.26.0";
+  chartHash = "sha256-b4ke7Ok2Qk9P3S9uxoY05ua5R2efDCi78x0ramQOoyw=";
+}


### PR DESCRIPTION
Add Helm chart for Hetzners Cloud Controller Manager.